### PR TITLE
Try setuptools before trying distools. Force required packages to ins…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 with open('README.rst') as file:
         long_description = file.read()
 
@@ -14,22 +18,27 @@ except LookupError:
 setup(
     name='powerlaw',
     py_modules=['powerlaw'],
-    version= '1.3.1',
+    version= '1.3.2',
     description='Toolbox for testing if a probability distribution fits a power law',
     long_description=long_description,
     author='Jeff Alstott',
     author_email='jeffalstott@gmail.com',
     url='http://www.github.com/jeffalstott/powerlaw',
-        requires=['scipy', 'numpy', 'matplotlib', 'mpmath'],
-        license='MIT',
-        classifiers=[
-            'License :: OSI Approved :: MIT License',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
-            'Operating System :: OS Independent',
-            'Topic :: Scientific/Engineering :: Mathematics',
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Science/Research'
-        ]
+    install_requires=[
+        'numpy', 
+        'scipy', 
+        'matplotlib', 
+        'mpmath'
+    ],
+    license='MIT',
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Science/Research'
+    ]
 )


### PR DESCRIPTION
…tall

This will download all the requirements for powerlaw when running setup.py if setuptools is installed. It will also catch the exception that setuptools is not installed and revert back to using distools.